### PR TITLE
Python code for arrays and one C# example for 3D arrays

### DIFF
--- a/data-structures/arrays/c-sharp/array_3D_output_all.cs
+++ b/data-structures/arrays/c-sharp/array_3D_output_all.cs
@@ -1,0 +1,84 @@
+/*
+Isaac Computer Science
+Usage licensed under the Open Government Licence v3.0
+
+Note: This file is designed to be copied out and compiled on your machine.
+In order for it to compile properly you need to ensure that the project name is the same as the "namespace" in this file.
+To run this file you need to:
+1. Copy the contents
+2. Paste them into the C# IDE of your choice (Visual Studio, for example)
+3. Change the namespace to match your project (if necessary)
+4. Compile the program
+5. Run the program
+*/
+
+using System;
+
+namespace IsaacCodeSamples
+{
+    class DataStructures
+    {
+        // The Main method is the entry point for all C# programs
+        public static void Main()
+        {
+            // Create a three-dimensional array
+            string[,,] myArray = Create3DArray();
+
+            // Output every element in the array
+            Console.WriteLine("### Output each element in the 3D array ###");
+            OutputEachElement(myArray);
+        }
+
+        public static string[,,] Create3DArray()
+        {
+            // Declare and initialise a three-dimensional array
+            string[,,] spellingWords = new string[2, 3, 5] { 
+                { 
+                    { "me", "do", "her", "it", "him" }, 
+                    { "put", "ask", "says", "red", "any" }, 
+                    { "they", "where", "friend", "fast", "class" }
+                },
+                { 
+                    { "door", "find", "most", "bath", "eye" }, 
+                    { "every", "great", "climb", "prove", "behind" }, 
+                    { "clothes", "again", "improve", "should", "parents" } 
+                } 
+            };
+
+            /*
+            // Declare an array of 2 x 3 x 5 elements
+            string[,,] spellingWords = new string[2, 3, 5];
+
+            // Assign words into different positions in the array
+            spellingWords[0, 0, 4] = "him";
+            spellingWords[0, 2, 1] = "where";
+            spellingWords[1, 1, 0] = "every";
+            spellingWords[1, 2, 4] = "parents";
+            */
+
+            // Return the array
+            return spellingWords;
+        }
+
+
+        // Output every element in a three-dimensional array
+        public static void OutputEachElement(string[,,] givenArray)
+        {
+            // Repeat for each year
+            for (int year = 0; year < givenArray.GetLength(0); year++)
+            {
+                // Repeat for each level
+                for (int level = 0; level < givenArray.GetLength(1); level++)
+                {
+                    // Output each word for the current year and level
+                    for (int word = 0; word < givenArray.GetLength(2); word++)
+                    {
+                        Console.WriteLine(givenArray[year, level, word]);
+                    }
+                }
+            }
+        }
+
+        
+    }
+}

--- a/data-structures/arrays/c-sharp/array_3D_output_all.cs
+++ b/data-structures/arrays/c-sharp/array_3D_output_all.cs
@@ -25,7 +25,7 @@ namespace IsaacCodeSamples
             string[,,] myArray = Create3DArray();
 
             // Output every element in the array
-            Console.WriteLine("### Output each element in the 3D array ###"); # test
+            Console.WriteLine("### Output each element in the 3D array ###");
             OutputEachElement(myArray);
         }
 

--- a/data-structures/arrays/c-sharp/array_3D_output_all.cs
+++ b/data-structures/arrays/c-sharp/array_3D_output_all.cs
@@ -25,7 +25,7 @@ namespace IsaacCodeSamples
             string[,,] myArray = Create3DArray();
 
             // Output every element in the array
-            Console.WriteLine("### Output each element in the 3D array ###");
+            Console.WriteLine("### Output each element in the 3D array ###"); # test
             OutputEachElement(myArray);
         }
 

--- a/data-structures/arrays/python/array_1D_output_all.py
+++ b/data-structures/arrays/python/array_1D_output_all.py
@@ -1,0 +1,49 @@
+# Isaac Computer Science
+# Usage licensed under the Open Government Licence v3.0
+
+
+def create_list():
+    """Create a list of words"""
+
+    # Declare an empty list
+    spelling_words = []
+
+    # Append 10 words to the list
+    spelling_words.append("path")
+    spelling_words.append("floor")
+    spelling_words.append("sugar")
+    spelling_words.append("because")
+    spelling_words.append("beautiful")
+    spelling_words.append("clothes")
+    spelling_words.append("whole")
+    spelling_words.append("behind")
+    spelling_words.append("move")
+    spelling_words.append("busy")
+
+    # Return the list
+    return spelling_words
+
+
+def output_each_element(given_list):
+    """Output every element in a list"""
+
+    # Output each word in the list
+    for i in range(0, len(given_list)):
+        print(given_list[i])
+
+
+def main():
+    """Create a list and output every element"""
+
+    # Create a list
+    my_list = create_list()
+
+    # Output every element in the list
+    print("### Output each element in the list ###")
+    output_each_element(my_list)
+
+
+# This code will run if this file is executed directly
+# (i.e. not called by another program)
+if __name__ == '__main__':
+    main()

--- a/data-structures/arrays/python/array_1D_output_single.py
+++ b/data-structures/arrays/python/array_1D_output_single.py
@@ -1,0 +1,41 @@
+# Isaac Computer Science
+# Usage licensed under the Open Government Licence v3.0
+
+
+def create_list():
+    """Create a list of words"""
+
+    # Declare an empty list
+    spelling_words = []
+
+    # Append 10 words to the list
+    spelling_words.append("path")
+    spelling_words.append("floor")
+    spelling_words.append("sugar")
+    spelling_words.append("because")
+    spelling_words.append("beautiful")
+    spelling_words.append("clothes")
+    spelling_words.append("whole")
+    spelling_words.append("behind")
+    spelling_words.append("move")
+    spelling_words.append("busy")
+
+    # Return the list
+    return spelling_words
+
+
+def main():
+    """Create a list and output a single element"""
+
+    # Create a list
+    my_list = create_list()
+
+    # Output a single element from the list
+    print("### Output a single element from the list ###")
+    print(my_list[2])
+
+
+# This code will run if this file is executed directly
+# (i.e. not called by another program)
+if __name__ == '__main__':
+    main()

--- a/data-structures/arrays/python/array_2D_output_all.py
+++ b/data-structures/arrays/python/array_2D_output_all.py
@@ -1,0 +1,47 @@
+# Isaac Computer Science
+# Usage licensed under the Open Government Licence v3.0
+
+
+# Index values of each level
+LEVEL1 = 0 
+LEVEL2 = 1
+LEVEL3 = 2
+
+
+def create_2D_list():
+    """Create a two-dimensional list of words and levels"""
+
+    # Declare and initialise a two-dimensional list
+    spelling_words = [["any", "poor", "gold", "wild", "kind"],
+                      ["both", "break", "pretty", "floor", "water"],
+                      ["sugar", "clothes", "again", "money", "children"]]
+
+    # Return the list
+    return spelling_words
+
+
+def output_each_element(given_list):
+    """Output every element in a two-dimensional list"""
+
+    # Repeat for each level
+    for level in range(0, len(given_list)):
+        # Output each word for the current level
+        for word in range(0, len(given_list[level])):
+             print(given_list[level][word])
+
+
+def main():
+    """Create a list and output every element"""
+
+    # Create a two-dimensional list
+    my_list = create_2D_list()
+
+    # Output every element in the list
+    print("### Output each element in the 2D list ###")
+    output_each_element(my_list)
+
+
+# This code will run if this file is executed directly
+# (i.e. not called by another program)
+if __name__ == '__main__':
+    main()

--- a/data-structures/arrays/python/array_2D_output_level1.py
+++ b/data-structures/arrays/python/array_2D_output_level1.py
@@ -1,0 +1,45 @@
+# Isaac Computer Science
+# Usage licensed under the Open Government Licence v3.0
+
+
+# Index values of each level
+LEVEL1 = 0 
+LEVEL2 = 1
+LEVEL3 = 2
+
+
+def create_2D_list():
+    """Create a two-dimensional list of words and levels"""
+
+    # Declare and initialise a two-dimensional list
+    spelling_words = [["any", "poor", "gold", "wild", "kind"],
+                      ["both", "break", "pretty", "floor", "water"],
+                      ["sugar", "clothes", "again", "money", "children"]]
+
+    # Return the list
+    return spelling_words
+
+
+def output_level(given_list, level):
+    """Output every element from a single level"""
+
+    # Output each word from a particular level
+    for word in range(0, len(given_list[level])):
+         print(given_list[level][word])
+
+
+def main():
+    """Create a list and output every element in a single level"""
+
+    # Create a two-dimensional list
+    my_list = create_2D_list()
+
+    # Output every element for level 1
+    print("### Output each element for level 1 ###")
+    output_level(my_list, LEVEL1)
+
+
+# This code will run if this file is executed directly
+# (i.e. not called by another program)
+if __name__ == '__main__':
+    main()

--- a/data-structures/arrays/python/array_2D_output_single.py
+++ b/data-structures/arrays/python/array_2D_output_single.py
@@ -1,0 +1,37 @@
+# Isaac Computer Science
+# Usage licensed under the Open Government Licence v3.0
+
+
+# Index values of each level
+LEVEL1 = 0 
+LEVEL2 = 1
+LEVEL3 = 2
+
+
+def create_2D_list():
+    """Create a two-dimensional list of words and levels"""
+
+    # Declare and initialise a two-dimensional list
+    spelling_words = [["any", "poor", "gold", "wild", "kind"],
+                      ["both", "break", "pretty", "floor", "water"],
+                      ["sugar", "clothes", "again", "money", "children"]]
+
+    # Return the list
+    return spelling_words
+
+
+def main():
+    """Create a list and output every element"""
+
+    # Create a two-dimensional list
+    my_list = create_2D_list()
+
+    # Output a single element from the list
+    print("### Output a single element from the 2D list ###")
+    print(my_list[LEVEL2][3])
+
+
+# This code will run if this file is executed directly
+# (i.e. not called by another program)
+if __name__ == '__main__':
+    main()

--- a/data-structures/arrays/python/array_3D_output_all.py
+++ b/data-structures/arrays/python/array_3D_output_all.py
@@ -1,0 +1,62 @@
+# Isaac Computer Science
+# Usage licensed under the Open Government Licence v3.0
+
+
+# Index values of each year
+YEAR1 = 0
+YEAR2 = 1
+
+# Index values of each level
+LEVEL1 = 0 
+LEVEL2 = 1
+LEVEL3 = 2
+
+
+def create_3D_list():
+    """Create a three-dimensional list of words, levels and years"""
+
+    # Declare and initialise a three-dimensional list
+    spelling_words = [
+        [
+            ["me", "do", "her", "it", "him"],
+            ["put", "ask", "says", "red", "any"],
+            ["they", "where", "friend", "fast", "class"]
+        ],
+        [
+            ["door", "find", "most", "bath", "eye"],
+            ["every", "great", "climb", "prove", "behind"],
+            ["clothes", "again", "improve", "should", "parents"]
+        ]
+    ]
+
+    # Return the list
+    return spelling_words
+
+
+def output_each_element(given_list):
+    """Output every element in a three-dimensional list"""
+
+    # Repeat for each year
+    for year in range(0, len(given_list)):
+        # Repeat for each level
+        for level in range(0, len(given_list[year])):
+            # Output each word for the current year and level
+            for word in range(0, len(given_list[year][level])):
+                 print(given_list[year][level][word])
+
+
+def main():
+    """Create a list and output every element"""
+
+    # Create a three-dimensional list
+    my_list = create_3D_list()
+
+    # Output every element in the list
+    print("### Output each element in the 3D list ###")
+    output_each_element(my_list)
+
+
+# This code will run if this file is executed directly
+# (i.e. not called by another program)
+if __name__ == '__main__':
+    main()

--- a/data-structures/arrays/python/array_3D_output_single.py
+++ b/data-structures/arrays/python/array_3D_output_single.py
@@ -1,0 +1,50 @@
+# Isaac Computer Science
+# Usage licensed under the Open Government Licence v3.0
+
+
+# Index values of each year
+YEAR1 = 0
+YEAR2 = 1
+
+# Index values of each level
+LEVEL1 = 0 
+LEVEL2 = 1
+LEVEL3 = 2
+
+
+def create_3D_list():
+    """Create a three-dimensional list of words, levels and years"""
+
+    # Declare and initialise a three-dimensional list
+    spelling_words = [
+        [
+            ["me", "do", "her", "it", "him"],
+            ["put", "ask", "says", "red", "any"],
+            ["they", "where", "friend", "fast", "class"]
+        ],
+        [
+            ["door", "find", "most", "bath", "eye"],
+            ["every", "great", "climb", "prove", "behind"],
+            ["clothes", "again", "improve", "should", "parents"]
+        ]
+    ]
+
+    # Return the list
+    return spelling_words
+
+
+def main():
+    """Create a list and output a single element"""
+
+    # Create a three-dimensional list
+    my_list = create_3D_list()
+
+    # Output a single element from the list
+    print("### Output a single element from the 3D list ###")
+    print(my_list[YEAR2][LEVEL3][4])
+
+
+# This code will run if this file is executed directly
+# (i.e. not called by another program)
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I've changed the pseudocode as well on the [Arrays content page](https://editor.isaaccomputerscience.org/edit/master/content/computer_science/data_structures_and_algorithms/data_structures/dsa_datastruct_array_NEW.json) which needs QA too.

However, the declaration examples for 2D and 3D arrays in pseudocode and real code do not match. In Python, you can declare an empty 3D array ok like this `my_array = [[[]]]` but then adding single items to anything apart from the list at position 0, 0 requires you to create and append a new list. There is an example of both ways of doing it in C# in the first example for 3D arrays.

I'm wondering whether: 
a) it matters if the pseudocode and real code don't match (see the explanations in the Python tabs) or
b) the pseudocode should change to match more closely with the real code

For either option, we could also split the 2D/3D array declaration out from the initialisation so that at least the declaration is fairly similar across the board. Then decide on option a) or b) for the initialisation. Sorry for the long message!